### PR TITLE
feat: enable VPC flow logs

### DIFF
--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -3,12 +3,15 @@ variable "notify_key" {
   sensitive = true
 }
 
-
 variable "rds_password" {
   type      = string
   sensitive = true
 }
 
 variable "rds_username" {
+  type = string
+}
+
+variable "rds_proxy_security_group_id" {
   type = string
 }

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -3,5 +3,27 @@ module "vpc" {
   name              = var.product_name
   billing_tag_value = var.billing_code
   high_availability = true
-  enable_flow_log   = false
+  enable_flow_log   = true
+}
+
+data "aws_security_group" "rds_proxy_sg" {
+  id = var.rds_proxy_security_group_id
+}
+
+resource "aws_security_group_rule" "rds_sg_egress_443" {
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = data.aws_security_group.rds_proxy_sg.id
+}
+
+resource "aws_security_group_rule" "rds_sg_egress_5432" {
+  type              = "egress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  security_group_id = data.aws_security_group.rds_proxy_sg.id
+  self              = true
 }

--- a/terragrunt/env/api/terragrunt.hcl
+++ b/terragrunt/env/api/terragrunt.hcl
@@ -2,9 +2,9 @@ terraform {
   source = "../../aws//api"
 }
 
-
 inputs = {
-  rds_username = "databaseuser"
+  rds_username                = "databaseuser"
+  rds_proxy_security_group_id = "sg-0fe09739f4ab9712d"
 }
 
 include {


### PR DESCRIPTION
# Summary
This will allow us to diagnose the Lambda internet connectivity issues.

Also adds the 443 egress rules to the security group used by the Lambda.

Related #5 