### PR TITLE
fix: remove the duplicated 5432 egress rule

### DIFF
--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -18,12 +18,3 @@ resource "aws_security_group_rule" "rds_sg_egress_443" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = data.aws_security_group.rds_proxy_sg.id
 }
-
-resource "aws_security_group_rule" "rds_sg_egress_5432" {
-  type              = "egress"
-  from_port         = 5432
-  to_port           = 5432
-  protocol          = "tcp"
-  security_group_id = data.aws_security_group.rds_proxy_sg.id
-  self              = true
-}


### PR DESCRIPTION
# Summary
This is already part of the RDS proxy security group.

Note, this was applied locally, so there should be no Terraform plan changes.

Related #5 