### PR TITLE
feat: add Route53 hosted zone

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -43,6 +43,15 @@ jobs:
             api:
               - 'terragrunt/aws/api/**'
               - 'terragrunt/env/api/**'
+            hosted_zone:
+              - 'terragrunt/aws/hosted_zone/**'
+              - 'terragrunt/env/hosted_zone/**'
+
+      - name: Apply hosted_zone
+        if: ${{ steps.filter.outputs.hosted_zone == 'true' }}
+        working-directory: terragrunt/env/hosted_zone
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply api
         if: ${{ steps.filter.outputs.api == 'true' }}

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         include:
           - module: api
+          - module: hosted_zone
 
     runs-on: ubuntu-latest
     steps:

--- a/terragrunt/aws/hosted_zone/hosted_zone.tf
+++ b/terragrunt/aws/hosted_zone/hosted_zone.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "list_manager" {
+  name = var.hosted_zone_name
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}

--- a/terragrunt/aws/hosted_zone/inputs.tf
+++ b/terragrunt/aws/hosted_zone/inputs.tf
@@ -1,0 +1,4 @@
+variable "hosted_zone_name" {
+  description = "(Required) Name of the Route53 hosted zone"
+  type        = string
+}

--- a/terragrunt/aws/hosted_zone/outputs.tf
+++ b/terragrunt/aws/hosted_zone/outputs.tf
@@ -1,0 +1,3 @@
+output "hosted_zone_id" {
+  value = aws_route53_zone.list_manager.zone_id
+}

--- a/terragrunt/env/hosted_zone/terragrunt.hcl
+++ b/terragrunt/env/hosted_zone/terragrunt.hcl
@@ -1,0 +1,11 @@
+terraform {
+  source = "../../aws//hosted_zone"
+}
+
+inputs = {
+  hosted_zone_name = "list-manager.alpha.canada.ca"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
This creates a hosted zone named `list-manager.alpha.canada.ca` that will be used to manage the list manager DNS records.

Closes #31 
Related #32 