### PR TITLE
feat: remove `v1` root path from FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ Bring up the local dev environment:
 make dev
 ```
 
-Currently, we append the `/v1` for our deployment, but locally you don't need this. So to view the docs, you have to change `api.py` from:
-```
-app = FastAPI(root_path="/v1")
-```
-to:
-```
-app = FastAPI(root_path="/")
-```
-
 ## Load testing
 The API contains a `locust` file to test a basic workflow:
 

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -22,7 +22,7 @@ METRICS_SMS_TARGET = "sms"
 NOTIFY_KEY = environ.get("NOTIFY_KEY")
 REDIRECT_ALLOW_LIST = ["valid.canada.ca", "valid.gc.ca"]
 
-app = FastAPI(root_path="/v1")
+app = FastAPI()
 metrics = Metrics(namespace="ListManager", service="api")
 
 


### PR DESCRIPTION
# Summary
The `v1` root path is no longer needed now that the API Gateway has a custom domain name mapped to the `v1` stage.

Related #32 