### PR TITLE
feat: add metrics on 500 and 429 errors on logs

### DIFF
--- a/terragrunt/aws/api/cloudwatch_alert.tf
+++ b/terragrunt/aws/api/cloudwatch_alert.tf
@@ -27,6 +27,35 @@ resource "aws_cloudwatch_metric_alarm" "logs-10-500-error-5-minutes-critical" {
   ok_actions          = [aws_sns_topic.critical.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "logs-1-502-error-1-minute-warning" {
+  alarm_name          = "logs-1-502-error-1-minute-warning"
+  alarm_description   = "One 502 error in 1 minute"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.lambda-502-errors.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.lambda-502-errors.metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.warning.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "logs-10-502-error-5-minutes-critical" {
+  alarm_name          = "logs-10-502-error-5-minutes-critical"
+  alarm_description   = "Ten 502 errors in 5 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.lambda-502-errors.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.lambda-502-errors.metric_transformation[0].namespace
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.critical.arn]
+  ok_actions          = [aws_sns_topic.critical.arn]
+}
+
 resource "aws_cloudwatch_metric_alarm" "logs-1-429-error-1-minute-warning" {
   alarm_name          = "logs-1-429-error-1-minute-warning"
   alarm_description   = "One 429 error in 1 minute"

--- a/terragrunt/aws/api/cloudwatch_log.tf
+++ b/terragrunt/aws/api/cloudwatch_log.tf
@@ -13,6 +13,18 @@ resource "aws_cloudwatch_log_metric_filter" "lambda-500-errors" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "lambda-502-errors" {
+  name           = "502-errors"
+  pattern        = "\"\\\" 502 \""
+  log_group_name = "aws/lambda/${aws_lambda_function.api.function_name}"
+
+  metric_transformation {
+    name      = "502-errors"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
 resource "aws_cloudwatch_log_metric_filter" "lambda-429-errors" {
   name           = "429-errors"
   pattern        = "\"\\\" 429 \""


### PR DESCRIPTION
Closes #50. This PR creates metrics and alerts for 500 and 429 error found in the api lambda logs. These then get sent to `warning` and `critical` SNS topics.