### PR TITLE
fix: adds slash to log group name

### DIFF
--- a/terragrunt/aws/api/cloudwatch_log.tf
+++ b/terragrunt/aws/api/cloudwatch_log.tf
@@ -4,7 +4,7 @@
 resource "aws_cloudwatch_log_metric_filter" "lambda-500-errors" {
   name           = "500-errors"
   pattern        = "\"\\\" 500 \""
-  log_group_name = "aws/lambda/${aws_lambda_function.api.function_name}"
+  log_group_name = "/aws/lambda/${aws_lambda_function.api.function_name}"
 
   metric_transformation {
     name      = "500-errors"
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_log_metric_filter" "lambda-500-errors" {
 resource "aws_cloudwatch_log_metric_filter" "lambda-502-errors" {
   name           = "502-errors"
   pattern        = "\"\\\" 502 \""
-  log_group_name = "aws/lambda/${aws_lambda_function.api.function_name}"
+  log_group_name = "/aws/lambda/${aws_lambda_function.api.function_name}"
 
   metric_transformation {
     name      = "502-errors"
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_log_metric_filter" "lambda-502-errors" {
 resource "aws_cloudwatch_log_metric_filter" "lambda-429-errors" {
   name           = "429-errors"
   pattern        = "\"\\\" 429 \""
-  log_group_name = "aws/lambda/${aws_lambda_function.api.function_name}"
+  log_group_name = "/aws/lambda/${aws_lambda_function.api.function_name}"
 
   metric_transformation {
     name      = "429-errors"


### PR DESCRIPTION
Log groups need to start with a slash