### PR TITLE
feat: add CloudWatch alarm notifications to Slack

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -11,6 +11,7 @@ env:
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
   TF_VAR_notify_key: ${{ secrets.TF_VARS_NOTIFY_KEY }}
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
+  TF_VAR_slack_webhook_url: ${{ secrets.TF_VARS_SLACK_WEBHOOK_URL }}
 
 jobs:
   terragrunt-apply:

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -14,6 +14,7 @@ env:
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
   TF_VAR_notify_key: ${{ secrets.TF_VARS_NOTIFY_KEY }}
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
+  TF_VAR_slack_webhook_url: ${{ secrets.TF_VARS_SLACK_WEBHOOK_URL }}
 
 jobs:
   terraform-plan:

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -28,3 +28,8 @@ variable "rds_username" {
 variable "rds_proxy_security_group_id" {
   type = string
 }
+
+variable "slack_webhook_url" {
+  type      = string
+  sensitive = true
+}

--- a/terragrunt/aws/api/notify_slack/LICENSE
+++ b/terragrunt/aws/api/notify_slack/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/terragrunt/aws/api/notify_slack/notify_slack.py
+++ b/terragrunt/aws/api/notify_slack/notify_slack.py
@@ -1,0 +1,107 @@
+
+"""
+Adopted from https://github.com/terraform-aws-modules/terraform-aws-notify-slack
+under Apache 2.0 license
+"""
+
+from __future__ import print_function
+from urllib.error import HTTPError
+import os, boto3, json, base64
+import urllib.request, urllib.parse
+import logging
+
+
+def cloudwatch_notification(message, region):
+  states = {'OK': 'good', 'INSUFFICIENT_DATA': 'warning', 'ALARM': 'danger'}
+  cloudwatch_url = "https://console.aws.amazon.com/cloudwatch/home?region="
+
+  return {
+    "color": states[message['NewStateValue']],
+    "fallback": "Alarm {} triggered".format(message['AlarmName']),
+    "fields": [
+      { "title": "Name", "value": message['AlarmName'], "short": True },
+      { "title": "Description", "value": message['AlarmDescription'], "short": False},
+      { "title": "Reason", "value": message['NewStateReason'], "short": False},
+      { "title": "Old State", "value": message['OldStateValue'], "short": True },
+      { "title": "Current State", "value": message['NewStateValue'], "short": True },
+      {
+        "title": "Link to Alarm",
+        "value": cloudwatch_url + region + "#alarm:alarmFilter=ANY;name=" + urllib.parse.quote(message['AlarmName']),
+        "short": False
+      }
+    ]
+  }
+
+
+def default_notification(subject, message):
+  attachments = {
+    "fallback": "A new message",
+    "title": subject if subject else "Message",
+    "mrkdwn_in": ["value"],
+    "fields": []
+  }
+  if type(message) is dict:
+    for k, v in message.items():
+      value = f"`{json.dumps(v)}`" if isinstance(v, (dict, list)) else str(v)
+      attachments['fields'].append(
+        {
+          "title": k,
+          "value": value,
+          "short": len(value) < 25
+        }
+      )
+  else:
+    attachments['fields'].append({"value": message, "short": False})
+
+  return attachments
+
+
+# Send a message to a slack channel
+def notify_slack(subject, message, region):
+  project_name = os.environ['PROJECT_NAME']
+  slack_url = os.environ['SLACK_WEBHOOK_URL']
+  payload = {
+    "attachments": []
+  }
+
+  if type(message) is str:
+    try:
+      message = json.loads(message)
+    except json.JSONDecodeError as err:
+      logging.exception(f'JSON decode error: {err}')
+
+  if "AlarmName" in message:
+    notification = cloudwatch_notification(message, region)
+    payload['text'] = project_name + " CloudWatch"
+    payload['attachments'].append(notification)
+  elif "attachments" in message or "text" in message:
+    payload = {**payload, **message}
+  else:
+    payload['text'] = "AWS notification"
+    payload['attachments'].append(default_notification(subject, message))
+
+  data = urllib.parse.urlencode({"payload": json.dumps(payload)}).encode("utf-8")
+  req = urllib.request.Request(slack_url)
+
+  try:
+    result = urllib.request.urlopen(req, data)
+    return json.dumps({"code": result.getcode(), "info": result.info().as_string()})
+
+  except HTTPError as e:
+    logging.error("{}: result".format(e))
+    return json.dumps({"code": e.getcode(), "info": e.info().as_string()})
+
+
+def lambda_handler(event, context):
+  if 'LOG_EVENTS' in os.environ and os.environ['LOG_EVENTS'] == 'True':
+    logging.warning('Event logging enabled: `{}`'.format(json.dumps(event)))
+
+  subject = event['Records'][0]['Sns']['Subject']
+  message = event['Records'][0]['Sns']['Message']
+  region = event['Records'][0]['Sns']['TopicArn'].split(":")[3]
+  response = notify_slack(subject, message, region)
+
+  if json.loads(response)["code"] != 200:
+    logging.error("Error: received status `{}` using event `{}` and context `{}`".format(json.loads(response)["info"], event, context))
+
+  return response

--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -1,3 +1,6 @@
+#
+# SNS: topics & subscriptions
+#
 resource "aws_sns_topic" "critical" {
   name              = "critical-alert-list-manager"
   kms_master_key_id = aws_kms_key.list-manager.arn
@@ -10,6 +13,133 @@ resource "aws_sns_topic" "critical" {
 resource "aws_sns_topic" "warning" {
   name              = "warning-alert-list-manager"
   kms_master_key_id = aws_kms_key.list-manager.arn
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}
+
+resource "aws_sns_topic_subscription" "critical" {
+  topic_arn = aws_sns_topic.critical.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.notify_slack.arn
+}
+
+resource "aws_sns_topic_subscription" "warning" {
+  topic_arn = aws_sns_topic.warning.arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.notify_slack.arn
+}
+
+#
+# Lambda: post notifications to Slack
+#
+resource "aws_lambda_function" "notify_slack" {
+  # checkov:skip=CKV_AWS_115:No function-level concurrent execution limit required
+  # checkov:skip=CKV_AWS_116:No Dead Letter Queue required
+  function_name = "notify_slack"
+  description   = "Lambda function to post CloudWatch alarm notifications to a Slack channel."
+
+  filename    = data.archive_file.notify_slack.output_path
+  handler     = "notify_slack.lambda_handler"
+  runtime     = "python3.8"
+  timeout     = 30
+  memory_size = 1024
+
+  role             = aws_iam_role.notify_slack_lambda.arn
+  source_code_hash = filebase64sha256(data.archive_file.notify_slack.output_path)
+
+  environment {
+    variables = {
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      PROJECT_NAME      = "ListManager"
+      LOG_EVENTS        = "True"
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.notify_slack_lambda,
+    aws_cloudwatch_log_group.notify_slack_lambda,
+  ]
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+}
+
+data "archive_file" "notify_slack" {
+  type        = "zip"
+  source_file = "notify_slack/notify_slack.py"
+  output_path = "/tmp/notify_slack.py.zip"
+}
+
+resource "aws_lambda_permission" "notify_slack_warning" {
+  statement_id  = "AllowExecutionFromSNSWarning"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notify_slack.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.warning.arn
+}
+
+resource "aws_lambda_permission" "notify_slack_critical" {
+  statement_id  = "AllowExecutionFromSNSCritical"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notify_slack.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.critical.arn
+}
+
+#
+# IAM: Lambda logs
+#
+resource "aws_iam_role" "notify_slack_lambda" {
+  name               = "NotifySlackLambda"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_policy.json
+}
+
+resource "aws_iam_policy" "notify_slack_lambda" {
+  name   = "NotifySlackLambda"
+  path   = "/"
+  policy = data.aws_iam_policy_document.notify_slack_lambda.json
+}
+
+resource "aws_iam_role_policy_attachment" "notify_slack_lambda" {
+  role       = aws_iam_role.notify_slack_lambda.name
+  policy_arn = aws_iam_policy.notify_slack_lambda.arn
+}
+
+data "aws_iam_policy_document" "lambda_assume_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "notify_slack_lambda" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      aws_cloudwatch_log_group.notify_slack_lambda.arn
+    ]
+  }
+}
+
+#
+# CloudWatch: Lambda logs
+#
+resource "aws_cloudwatch_log_group" "notify_slack_lambda" {
+  name              = "/aws/lambda/notify_slack"
+  retention_in_days = "14"
 
   tags = {
     CostCenter = var.billing_code


### PR DESCRIPTION
# Summary 
CloudWatch will now post alarm state change notifications to
Slack using the incoming webhook URL.

Closes #51 