### PR TITLE
fix: exclude WAF GenericRFI_BODY rule

### DIFF
--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -41,6 +41,10 @@ resource "aws_wafv2_web_acl" "api_waf" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        excluded_rule {
+          name = "GenericRFI_BODY"
+        }
       }
     }
 


### PR DESCRIPTION
# Summary
The `GenericRFI_BODY` rule in the AWS Common ruleset is blocking requests that have URLs as part of the payload.

Closes #69 