### PR TITLE
fix: devcontainer format on save and use ZSH

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,8 +42,13 @@
 				"password": "postgres"
 			}
 		],
-		"terminal.integrated.shell.linux": "/bin/zsh"
-	},
+		"[python]": {
+			"editor.formatOnSave": true
+		},
+		"[terraform]": {
+			"editor.formatOnSave": true
+		}
+	},	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - ..:/workspace:cached   
     command: sleep infinity
     environment:
+      SHELL: /bin/zsh
       <<: *db-connection-strings
 
   api:


### PR DESCRIPTION
# Summary
Set the devcontainer to format Python and Terraform on save.
Update the default shell to ZSH to take advantage of the autocomplete.