### PR TITLE
Add API key for send endpoint

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -437,6 +437,7 @@ class SendPayload(BaseModel):
     list_id: UUID
     template_id: UUID
     template_type: str
+    service_api_key: Optional[UUID]
     job_name: Optional[str] = "Bulk email"
     unique: Optional[bool] = True
 
@@ -523,7 +524,7 @@ def send_bulk_notify(subscription_count, send_payload, rows, recipient_limit=500
         if i == subscription_count - 1:
             notify_bulk_subscribers.append(subscription_rows)
 
-    notifications_client = get_notify_client()
+    notifications_client = get_notify_client(send_payload.service_api_key)
 
     count_sent = 0
     for subscribers in notify_bulk_subscribers:
@@ -535,7 +536,7 @@ def send_bulk_notify(subscription_count, send_payload, rows, recipient_limit=500
     return count_sent
 
 
-def get_notify_client():
+def get_notify_client(key=NOTIFY_KEY):
     return NotificationsAPIClient(
         NOTIFY_KEY, base_url="https://api.notification.canada.ca"
     )

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -704,6 +704,7 @@ def test_send_invalid_list(mock_client):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(uuid.uuid4()),
             "template_id": str(uuid.uuid4()),
             "template_type": "email",
@@ -724,6 +725,7 @@ def test_send_notify_error(mock_client, mock_db_session):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(uuid.uuid4()),
             "template_id": str(uuid.uuid4()),
             "template_type": "email",
@@ -740,6 +742,7 @@ def test_send_email(mock_client, list_fixture):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(list_fixture.id),
             "template_id": template_id,
             "template_type": "email",
@@ -837,6 +840,7 @@ def test_send_duplicate_emails(mock_client, list_fixture_with_duplicates):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(list_fixture_with_duplicates.id),
             "template_id": template_id,
             "template_type": "email",
@@ -852,6 +856,7 @@ def test_send_duplicate_emails(mock_client, list_fixture_with_duplicates):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(list_fixture_with_duplicates.id),
             "template_id": template_id,
             "template_type": "email",
@@ -872,6 +877,7 @@ def test_send_duplicate_phones(mock_client, list_fixture_with_duplicates):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(list_fixture_with_duplicates.id),
             "template_id": template_id,
             "template_type": "phone",
@@ -888,6 +894,7 @@ def test_send_duplicate_phones(mock_client, list_fixture_with_duplicates):
         "/send",
         headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
         json={
+            "service_api_key": str(uuid.uuid4()),
             "list_id": str(list_fixture_with_duplicates.id),
             "template_id": template_id,
             "template_type": "phone",


### PR DESCRIPTION
Based on this feature request 

> Add Drop down https://ircc.digital.canada.ca/wp-admin/admin.php?page=cds_notify_send
That allows selection of one of these services that IRCC will copy the template ID from.

Ref: https://github.com/cds-snc/GC-Articles/issues/55


This PR adds a service_id_api as an optional service_api_key parameter for the send endpoint.


@maxneuvians 
> currently the ListManager API can only handle one Notify API key, so either the API key needs to be sent with the /send request or you need some sort of mapping of service to API key in the list manager, ex: List model contains an API key field

 