### PR TITLE
Patch to fix validation for Notify API key

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -474,7 +474,7 @@ class SendPayload(BaseModel):
     list_id: UUID
     template_id: UUID
     template_type: str
-    service_api_key: Optional[UUID]
+    service_api_key: Optional[str]
     job_name: Optional[str] = "Bulk email"
     unique: Optional[bool] = True
 


### PR DESCRIPTION
Fixes validation error for Notify API key.  

<img width="699" alt="Screen Shot 2021-09-16 at 9 21 41 AM" src="https://user-images.githubusercontent.com/62242/133619881-71dc2afa-5a15-46ac-b08d-e645c5ffb3a4.png">

## Note:
Notify API Keys - are not a UUID

i.e. test-c05f1302-29fa-4245-b906-5fcf53499638-b1dc1ae0-7296-4fa5-9d6b-9f187ab2fe89
