### PR TITLE
fix: remove RDS READER CloudWatch alarms

### DIFF
--- a/terragrunt/aws/api/cloudwatch_api.tf
+++ b/terragrunt/aws/api/cloudwatch_api.tf
@@ -181,6 +181,7 @@ resource "aws_cloudwatch_metric_alarm" "waf-block-request-warning" {
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   threshold           = "10"
+  treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.warning.arn]
   ok_actions          = [aws_sns_topic.warning.arn]
 

--- a/terragrunt/aws/api/cloudwatch_rds.tf
+++ b/terragrunt/aws/api/cloudwatch_rds.tf
@@ -1,12 +1,6 @@
 #
 # RDS alarms
 # 
-locals {
-  rds_aurora_replica_lag_maximum = 2000
-  rds_cpu_maxiumum               = 80
-  rds_freeable_memory_minimum    = 64000000
-}
-
 resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_writer" {
   alarm_name          = "RDSCpuUtilizationWriter"
   comparison_operator = "GreaterThanThreshold"
@@ -15,7 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_writer" {
   namespace           = "AWS/RDS"
   period              = "300"
   statistic           = "Maximum"
-  threshold           = local.rds_cpu_maxiumum
+  threshold           = 80
 
   alarm_description = "CPU utilization for RDS cluster writer in a 5 minute period"
   alarm_actions     = [aws_sns_topic.warning.arn]
@@ -27,46 +21,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_writer" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_reader" {
-  alarm_name          = "RDSCpuUtilizationReader"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/RDS"
-  period              = "300"
-  statistic           = "Maximum"
-  threshold           = local.rds_cpu_maxiumum
-
-  alarm_description = "CPU utilization for RDS cluster reader in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.warning.arn]
-  ok_actions        = [aws_sns_topic.warning.arn]
-
-  dimensions = {
-    DBClusterIdentifier = module.rds.rds_cluster_id
-    Role                = "READER"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "rds_aurora_replica_lag" {
-  alarm_name          = "RdsAuroraReplicaLag"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "AuroraReplicaLag"
-  namespace           = "AWS/RDS"
-  period              = "300"
-  statistic           = "Maximum"
-  threshold           = local.rds_aurora_replica_lag_maximum
-
-  alarm_description = "Replica lag (milliseconds) for RDS cluster reader in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.warning.arn]
-  ok_actions        = [aws_sns_topic.warning.arn]
-
-  dimensions = {
-    DBClusterIdentifier = module.rds.rds_cluster_id
-    Role                = "READER"
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "rds_freeable_memory_writer" {
   alarm_name          = "RdsFreeableMemoryWriter"
   comparison_operator = "LessThanThreshold"
@@ -75,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_freeable_memory_writer" {
   namespace           = "AWS/RDS"
   period              = "300"
   statistic           = "Minimum"
-  threshold           = local.rds_freeable_memory_minimum
+  threshold           = 64000000
 
   alarm_description = "Minimum freeable memory (Bytes) for RDS cluster writer in a 5 minute period"
   alarm_actions     = [aws_sns_topic.warning.arn]
@@ -84,25 +38,5 @@ resource "aws_cloudwatch_metric_alarm" "rds_freeable_memory_writer" {
   dimensions = {
     DBClusterIdentifier = module.rds.rds_cluster_id
     Role                = "WRITER"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "rds_freeable_memory_reader" {
-  alarm_name          = "RdsFreeableMemoryReader"
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "FreeableMemory"
-  namespace           = "AWS/RDS"
-  period              = "300"
-  statistic           = "Minimum"
-  threshold           = local.rds_freeable_memory_minimum
-
-  alarm_description = "Freeable memory (Bytes) for RDS cluster reader in a 5 minute period"
-  alarm_actions     = [aws_sns_topic.warning.arn]
-  ok_actions        = [aws_sns_topic.warning.arn]
-
-  dimensions = {
-    DBClusterIdentifier = module.rds.rds_cluster_id
-    Role                = "READER"
   }
 }


### PR DESCRIPTION
# Summary
The RDS cluster for ListManager does not have any READER instances.

Also sets WAF to `notBreaching` for missing data to stop alarm flapping.