### PR TITLE
fix: SQLAlchemy connection pool settings

### DIFF
--- a/api/database/db.py
+++ b/api/database/db.py
@@ -12,5 +12,8 @@ db_engine = create_engine(
     connection_string,
     pool_size=1,
     max_overflow=0,
+    pool_pre_ping=True,  # Check that a connection is still active before attempting to use
+    pool_recycle=1500,  # Prune connections older than 25 minutes (RDS Proxy has a timeout of 30 minutes)
+    pool_use_lifo=True,  # Always re-use last connection used (allows server-side timeouts to remove unused connections)
 )
 db_session = sessionmaker(bind=db_engine)


### PR DESCRIPTION
# Summary
These connection pool settings do the following:

1. Test that a pool connection is still active before use.
2. Set a pool connection to expire sooner than the RDS Proxy timeout.
3. Always re-use the most recently used pool connection.  This allows server-side connection timeouts to timeout unused connections, which it probably not required in our case.

⚠️ &nbsp;**Note:** this problem may have been fixed as a side-effect of creating a Route53 health check, since the `/healthcheck` endpoint performs a database op.

Fixes #85 

