### PR TITLE
Add service api key for subscription endpoint

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -328,7 +328,10 @@ def create_subscription(
     response: Response,
     session: Session = Depends(get_db),
 ):
-    notifications_client = get_notify_client(subscription_payload.service_api_key)
+    if subscription_payload.service_api_key:
+        notifications_client = get_notify_client(subscription_payload.service_api_key)
+    else:
+        notifications_client = get_notify_client()
 
     try:
         list = session.query(List).get(subscription_payload.list_id)


### PR DESCRIPTION
The MVP team is looking to add subscribe functionality to [GC Articles]( https://github.com/cds-snc/gc-articles/pull/82)

In order for this to work with the current instance of List Manager we need to update the subscription endpoint to accept an API key param in turn allowing the Notify Client to send via the Service API key vs the default.

Note: We'll likely need to update some other endpoint later