### PR TITLE
fix:crash the app if auth token is not set

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
 settings = Settings()
 API_AUTH_TOKEN = environ.get("API_AUTH_TOKEN")
 if API_AUTH_TOKEN is None or not API_AUTH_TOKEN:
-    raise ValueError("error invalid API_AUTH_TOKEN")
+    raise Exception("error API_AUTH_TOKEN is missing")
 
 METRICS_EMAIL_TARGET = "email"
 METRICS_SMS_TARGET = "sms"

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -1156,6 +1156,6 @@ def test_api_docs_enabled_via_environ():
 
 
 @patch.dict(os.environ, clear=True)
-@pytest.mark.xfail(raises=ValueError)
+@pytest.mark.xfail(raises=Exception)
 def test_api_auth_token_not_set():
     reload(api)


### PR DESCRIPTION
# Summary | Résumé

Crash the app if the environment variable  `API_AUTH_TOKEN` is not set.
closed #68 
---
# Test instructions | Instructions pour tester la modification

1. Set the `API_AUTH_TOKEN` value to None or an empty string.
2. Attempting to run  the  app should fail. 
