### PR TITLE
chore: add prefix to VPC flow log objects

### DIFF
--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -72,7 +72,7 @@ resource "aws_security_group" "api" {
 }
 
 resource "aws_flow_log" "cloud_based_sensor" {
-  log_destination      = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+  log_destination      = "arn:aws:s3:::${var.cbs_satellite_bucket_name}/vpc_flow_logs/"
   log_destination_type = "s3"
   traffic_type         = "ALL"
   vpc_id               = module.vpc.vpc_id


### PR DESCRIPTION
# Summary
This will cause the VPC flow logs to appear in their own "folder"
in the S3 bucket.