### PR TITLE
feat: GZIP the WAF ACL logs in the S3 bucket

### DIFF
--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -256,9 +256,10 @@ resource "aws_kinesis_firehose_delivery_stream" "api_waf_logs" {
   }
 
   extended_s3_configuration {
-    role_arn   = aws_iam_role.write_waf_logs.arn
-    prefix     = "waf_acl_logs/AWSLogs/${var.account_id}/"
-    bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+    role_arn           = aws_iam_role.write_waf_logs.arn
+    prefix             = "waf_acl_logs/AWSLogs/${var.account_id}/"
+    bucket_arn         = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+    compression_format = "GZIP"
   }
 
   tags = {


### PR DESCRIPTION
# Summary
This will save storage costs in the satellite and log archive buckets.