### PR TITLE
Conditionally validate UUID and Urls

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -123,6 +123,7 @@ class ListCreatePayload(BaseModel):
         "unsubscribe_redirect_url",
         "subscribe_redirect_url",
         pre=True,
+        allow_reuse=True,
     )
     def blank_string(value, field):
         if value == "":


### PR DESCRIPTION
# Summary | Résumé

Fixes an issue with optional parameters submitted as empty strings.

When a property type is configured as `Optional[UUID]`, it is the equivalent of `Union[UUID,None]`, so it can accept either `UUID` or `None`. When a client submits an empty string through the API, it would fail the validation because '' is not the same as `None` and is not a valid `UUID`

This PR adds a custom validator that runs before other validations on those fields. It checks if the string being submitted is empty, and if so it changes it to `None` so it passes the validation.
