### PR TITLE
Return the Subscribe Redirect as payload from the Subscribe endpoint

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -481,7 +481,7 @@ def create_subscription(
             metrics.add_metadata(key="target", value=METRICS_SMS_TARGET)
 
         if list.subscribe_redirect_url is not None:
-            return RedirectResponse(list.subscribe_redirect_url)
+            return {"id": subscription.id, "redirect_url": list.subscribe_redirect_url}
         else:
             return {"id": subscription.id}
     except SQLAlchemyError as err:


### PR DESCRIPTION
# Summary | Résumé

The Subscription endpoint (Subscribe to a list) is called from the js layer in GC Articles, so the Redirect cannot be fired. Instead, return the "redirect_url" as a response from the endpoint so GC Articles can handle the redirect locally.
