### PR TITLE
Remove limit on body size for listimport requests

### DIFF
--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -107,6 +107,9 @@ resource "aws_wafv2_web_acl" "api_waf" {
         excluded_rule {
           name = "GenericRFI_BODY"
         }
+        excluded_rule {
+          name = "SizeRestrictions_BODY"
+        }
       }
     }
 
@@ -114,6 +117,55 @@ resource "aws_wafv2_web_acl" "api_waf" {
       cloudwatch_metrics_enabled = true
       metric_name                = "AWSManagedRulesCommonRuleSet"
       sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "Custom_SizeRestrictions_BODY"
+    priority = 25
+    action {
+      block {}
+    }
+
+    visibility_config {
+      sampled_requests_enabled   = true
+      cloudwatch_metrics_enabled = true
+      metric_name                = "Custom_SizeRestrictions_BODY"
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            field_to_match {
+              body {}
+            }
+            comparison_operator = "GT"
+            size                = "8192"
+            text_transformation {
+              type     = "NONE"
+              priority = 0
+            }
+          }
+        }
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                positional_constraint = "CONTAINS"
+                search_string         = "/listimport"
+                text_transformation {
+                  type     = "NONE"
+                  priority = 0
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

The `POST /listimport` endpoint can receive a payload of up to 10k email addresses. We were hitting this body size limit on the WAF firewall rule. This adds an exception for this endpoint.
