### PR TITLE
Feat/ 102 receive confirmation email on unsubscribe

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -717,7 +717,7 @@ def send_bulk_notify(subscription_count, send_payload, rows, recipient_limit=500
             # Reset and add headers
             subscription_rows = []
             if template_type == "email":
-                subscription_rows.append(["email address", "unsubscribe link"])
+                subscription_rows.append(["email address", "unsubscribe_link"])
             elif template_type == "phone":
                 subscription_rows.append(["phone number", "subscription id"])
 

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -882,7 +882,7 @@ def test_send_emails_only(mock_client):
         job_name="Job Name",
     )
 
-    subscriber_arr = [["email address", "unsubscribe link"]] + [
+    subscriber_arr = [["email address", "unsubscribe_link"]] + [
         [x["email"], get_unsubscribe_link(str(x["id"]))]
         for x in subscribers
         if x["email"]


### PR DESCRIPTION
# Summary | Résumé

> I want to receive a confirmation that I have successfully unsubscribed
---
## Minor Changes in this PR

1. `Send_bulk_notifications` replaces subscription id by `unsubscribe link` when sending email's notifications only.
```JSON
"rows": [
    ["email address", "name"],
    ["[alice@example.com](mailto:alice@example.com)", "Alice"],
    ["[bob@example.com](mailto:bob@example.com)", "Bob"]
  ],

to
"rows": [
    ["email address", "unsubscribe_link"],
    ["[alice@example.com](mailto:alice@example.com)", "link1"],
    ["[bob@example.com](mailto:bob@example.com)", "link2"]
  ],
```



