### PR TITLE
Expose testing db port to enable access

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: list-manager
+    ports:
+      - "5434:5432"
   
   localstack:
     image: localstack/localstack


### PR DESCRIPTION
# Summary | Résumé

Expose a port for the test database. Helpful when testing to see what data is being created etc.
