### PR TITLE
Prevent duplicate subscriptions

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -2,7 +2,6 @@
 # pylint: disable=missing-function-docstring
 
 from os import environ
-import traceback
 from uuid import UUID
 from fastapi import Depends, FastAPI, HTTPException, Response, Request, status
 from fastapi.responses import RedirectResponse, JSONResponse

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -10,7 +10,7 @@ from requests import HTTPError
 from sqlalchemy.exc import SQLAlchemyError, NoResultFound
 from sqlalchemy.sql.expression import func, cast
 from sqlalchemy.orm import Session
-from sqlalchemy import String, null
+from sqlalchemy import String
 from database.db import db_session
 from logger import log
 
@@ -499,8 +499,8 @@ class SubscriptionEvent(BaseModel):
 
 def get_subscription(
     list_id: str,
-    email: str = null,
-    phone: str = null,
+    email: str = None,
+    phone: str = None,
     session: Session = Depends(get_db),
 ):
     return (

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -10,7 +10,7 @@ from requests import HTTPError
 from sqlalchemy.exc import SQLAlchemyError, NoResultFound
 from sqlalchemy.sql.expression import func, cast
 from sqlalchemy.orm import Session
-from sqlalchemy import String, null, or_
+from sqlalchemy import String, null
 from database.db import db_session
 from logger import log
 

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -538,6 +538,10 @@ def create_subscription(
         response.status_code = status.HTTP_400_BAD_REQUEST
         return {"error": "email and phone can not be empty"}
 
+    if subscription_payload.email and subscription_payload.phone:
+        response.status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+        return {"error": "Must be one of Email or Phone"}
+
     try:
         subscription = get_subscription(
             list_id=list.id,

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-function-docstring
 
 from os import environ
+import traceback
 from uuid import UUID
 from fastapi import Depends, FastAPI, HTTPException, Response, Request, status
 from fastapi.responses import RedirectResponse, JSONResponse
@@ -503,9 +504,14 @@ def get_subscription(
     phone: str = null,
     session: Session = Depends(get_db),
 ):
-    return session.query(Subscription).filter(
-        (Subscription.email == email, Subscription.phone == phone),
-        Subscription.list_id == list_id,
+    return (
+        session.query(Subscription)
+        .filter(
+            Subscription.email == email,
+            Subscription.phone == phone,
+            Subscription.list_id == list_id,
+        )
+        .first()
     )
 
 
@@ -537,6 +543,7 @@ def create_subscription(
             list_id=list.id,
             email=subscription_payload.email,
             phone=subscription_payload.phone,
+            session=session,
         )
 
         if subscription is None:

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 
-from ast import Sub
 from os import environ
 from uuid import UUID
 from fastapi import Depends, FastAPI, HTTPException, Response, Request, status

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -583,7 +583,6 @@ def test_metrics(mock_mangum, context_fixture, capsys, metrics):
     log = capsys.readouterr().out.strip()
 
     metrics_output = json.loads(log)
-    print(metrics_output)
 
     metric_list = [
         "ListCreated",

--- a/api/tests/api_gateway/test_api_list_import.py
+++ b/api/tests/api_gateway/test_api_list_import.py
@@ -127,13 +127,6 @@ def test_email_list_with_unknown_error(
 
 
 def test_email_list_import_new(session, list_to_be_updated_fixture, client):
-    # Empty subscriptions table
-    data = (
-        session.query(Subscription)
-        .filter(Subscription.list_id == list_to_be_updated_fixture.id)
-        .delete()
-    )
-
     # create email list payload
     email_list = [f"email{str(x)}@example.com" for x in range(10)]
     response = client.post(
@@ -152,13 +145,6 @@ def test_email_list_import_new(session, list_to_be_updated_fixture, client):
 
 
 def test_phone_list_import(session, list_to_be_updated_fixture, client):
-    # Empty subscriptions table
-    data = (
-        session.query(Subscription)
-        .filter(Subscription.list_id == list_to_be_updated_fixture.id)
-        .delete()
-    )
-
     # create phone list payload
     phone_list = [f"555-{str(x)}55-5555" for x in range(10)]
     response = client.post(

--- a/api/tests/api_gateway/test_api_list_import.py
+++ b/api/tests/api_gateway/test_api_list_import.py
@@ -144,6 +144,51 @@ def test_email_list_import_new(session, list_to_be_updated_fixture, client):
     assert data.count() == 10
 
 
+def test_email_list_import_new_no_duplicates(
+    session, list_to_be_updated_fixture, client
+):
+    email_list = [f"email{str(x)}@example.com" for x in range(10)]
+    response = client.post(
+        f"/list/{list_to_be_updated_fixture.id}/import",
+        json={"email": email_list},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "OK"}
+
+    # Do it again with the same list
+    response = client.post(
+        f"/list/{list_to_be_updated_fixture.id}/import",
+        json={"email": email_list},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "OK"}
+
+    # Since we submitted the same list twice, should still be the same result (no dupes)
+    data = session.query(Subscription).filter(
+        Subscription.list_id == list_to_be_updated_fixture.id,
+        Subscription.email.is_not(None),
+        Subscription.confirmed.is_(True),
+    )
+    assert data.count() == 10
+
+    # Add 5 new emails to the previous list
+    email_list = [*email_list, *[f"email{str(x)}@example2.com" for x in range(5)]]
+    response = client.post(
+        f"/list/{list_to_be_updated_fixture.id}/import",
+        json={"email": email_list},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "OK"}
+
+    # There were five new emails in the list
+    data = session.query(Subscription).filter(
+        Subscription.list_id == list_to_be_updated_fixture.id,
+        Subscription.email.is_not(None),
+        Subscription.confirmed.is_(True),
+    )
+    assert data.count() == 15
+
+
 def test_phone_list_import(session, list_to_be_updated_fixture, client):
     # create phone list payload
     phone_list = [f"555-{str(x)}55-5555" for x in range(10)]

--- a/api/tests/api_gateway/test_api_subscritpion.py
+++ b/api/tests/api_gateway/test_api_subscritpion.py
@@ -98,13 +98,30 @@ def test_create_fails_with_email_and_phone_validation_error(
 
 
 @patch("api_gateway.api.get_notify_client")
-def test_create_succeeds_with_redirect(
+def test_create_email_sub_succeeds_with_redirect(
     mock_client, list_fixture_with_redirects, client
 ):
     response = client.post(
         "/subscription",
         json={
             "email": "test@example.com",
+            "list_id": str(list_fixture_with_redirects.id),
+        },
+    )
+    assert response.status_code == 307
+    assert response.headers == {
+        "location": list_fixture_with_redirects.subscribe_redirect_url
+    }
+
+
+@patch("api_gateway.api.get_notify_client")
+def test_create_phone_sub_succeeds_with_redirect(
+    mock_client, list_fixture_with_redirects, client
+):
+    response = client.post(
+        "/subscription",
+        json={
+            "phone": "14565434545",
             "list_id": str(list_fixture_with_redirects.id),
         },
     )
@@ -122,7 +139,6 @@ def test_create_subscription_with_undeclared_parameter(
         "/subscription",
         json={
             "email": "test@example.com",
-            "phone": "123456789",
             "list_id": str(list_fixture.id),
             "foo": "bar",
         },


### PR DESCRIPTION
# Summary | Résumé
Prevent duplicate subscriptions on both the individual Subscribe endpoint, and the Import endpoints. ie, the same `email` or same `phone` should not be associated with the same `list_id` more than once.

## Prevent duplicate Subscriptions
**POST /subscription**
In the case that someone does submit a duplicate email/list_id pair, or phone/list_id pair, we'll just fail silently and return a positive result. The rest of the confirmation flow will continue as normal (so as not to confuse a user who would be expecting a confirmation email), but no new subscription will be created.

## Prevent duplicates on import.
**POST /listimport**
**POST /list/[list_id]/import**
 When importing a list of Emails or Phone numbers, first retrieve the existing subscribers list, then find unique subscribers from the submitted list and only save those.