### PR TITLE
Update Subscriber counts to include SMS

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -570,6 +570,7 @@ def create_subscription(
 
         if (
             subscription_payload.phone is not None
+            and list.subscribe_phone_template_id is not None
             and len(list.subscribe_phone_template_id) == 36
         ):
             notifications_client.send_sms_notification(

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -314,7 +314,7 @@ def lists_by_service(service_id, session: Session = Depends(get_db)):
     return sanitized_lists
 
 
-@app.get("/lists/{service_id}/subscriber-count/")
+@app.get("/lists/{service_id}/subscriber-count/", deprecated=True)
 def get_list_counts(
     service_id,
     response: Response,

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -184,7 +184,7 @@ class ListGetPayload(ListCreatePayload):
 def lists(session: Session = Depends(get_db)) -> list[ListGetPayload]:
     sub_query = (
         session.query(
-            func.count(func.distinct(Subscription.email)).label("subscriber_count"),
+            func.count(Subscription.id).label("subscriber_count"),
             Subscription.list_id,
         )
         .filter(Subscription.confirmed.is_(True))
@@ -251,7 +251,7 @@ def lists(session: Session = Depends(get_db)) -> list[ListGetPayload]:
 def lists_by_service(service_id, session: Session = Depends(get_db)):
     sub_query = (
         session.query(
-            func.count(func.distinct(Subscription.email)).label("subscriber_count"),
+            func.count(Subscription.id).label("subscriber_count"),
             Subscription.list_id,
         )
         .filter(Subscription.confirmed.is_(True))
@@ -331,28 +331,15 @@ def get_list_counts(
         )
     )
 
-    if unique:
-        lists = (
-            session.query(
-                func.count(func.distinct(Subscription.email)), Subscription.list_id
-            )
-            .filter(
-                Subscription.list_id.in_(list_ids),
-                Subscription.confirmed.is_(True),
-            )
-            .group_by(Subscription.list_id)
-            .all()
+    lists = (
+        session.query(func.count(Subscription.id), Subscription.list_id)
+        .filter(
+            Subscription.list_id.in_(list_ids),
+            Subscription.confirmed.is_(True),
         )
-    else:
-        lists = (
-            session.query(func.count(Subscription.email), Subscription.list_id)
-            .filter(
-                Subscription.list_id.in_(list_ids),
-                Subscription.confirmed.is_(True),
-            )
-            .group_by(Subscription.list_id)
-            .all()
-        )
+        .group_by(Subscription.list_id)
+        .all()
+    )
 
     return list(
         map(

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -554,37 +554,6 @@ def test_counts_when_list_has_subscribers(
 
 
 @patch("api_gateway.api.get_notify_client")
-def test_unique_counts_for_list_subscribers(
-    mock_client,
-    session,
-    list_count_fixture_1,
-    client,
-):
-    # add subscribers to list 1
-    list_1_emails = [
-        {"email": "list1+0@example.com", "confirmed": False},
-        {"email": "list1+1@example.com", "confirmed": True},
-        {"email": "list1+2@example.com", "confirmed": True},
-        {"email": "list1+1@example.com", "confirmed": True},
-        {"email": "list1+1@example.com", "confirmed": True},
-    ]
-
-    subscribe_users(session, list_1_emails, list_count_fixture_1)
-
-    response = client.get(
-        f"/lists/{str(list_count_fixture_1.service_id)}/subscriber-count?unique=1",
-        headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
-    )
-
-    data = response.json()
-
-    # check list 1
-    item = find_item_in_dict_list(data, "list_id", str(list_count_fixture_1.id))
-    assert item is not None
-    assert item["subscriber_count"] == 2
-
-
-@patch("api_gateway.api.get_notify_client")
 def test_remove_all_subscribers_from_list(
     mock_client,
     session,

--- a/api/tests/api_gateway/test_api_send.py
+++ b/api/tests/api_gateway/test_api_send.py
@@ -36,10 +36,14 @@ def test_send_email(mock_client, list_fixture, client, session):
 
 @patch("api_gateway.api.get_notify_client")
 def test_send_email_with_personalisation(mock_client, list_fixture, client, session):
-    subscription0 = Subscription(
+    session.execute("""TRUNCATE TABLE subscriptions""")
+    session.commit()
+
+    subscription = Subscription(
         email="fake@email.com", list=list_fixture, confirmed=True
     )
-    session.add(subscription0)
+
+    session.add(subscription)
     session.commit()
 
     template_id = str(uuid.uuid4())
@@ -64,14 +68,13 @@ def test_send_email_with_personalisation(mock_client, list_fixture, client, sess
     assert response.status_code == 200
     assert data["status"] == "OK"
     assert data["sent"] == 1
-    session.expire_all()
 
     job_name = "Job Name"
     subscribers = [
         ["email address", "unsubscribe_link", "subject", "message"],
         [
             "fake@email.com",
-            f"https://list-manager.alpha.canada.ca/unsubscribe/{subscription0.id}",
+            f"https://list-manager.alpha.canada.ca/unsubscribe/{subscription.id}",
             "Subject for the email",
             "Message of the email",
         ],


### PR DESCRIPTION
# Summary | Résumé

- Modify subscriber_count on lists to include all subscriptions (incl. SMS)
- Remove unique constraint on subscriber_count as duplicates are prevented since #143 
- Fix a flaky test by truncating the Subscriptions table before running
- Deprecate subscriber_counts endpoint (counts now available on lists endpoints)
- Fix uncaught exception when missing subscribe_template_id
