### PR TITLE
Set the BASE_URL for confirm/unsub links to GC Articles

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -51,7 +51,7 @@ REDIRECT_ALLOW_LIST = [
     "articles.cdssandbox.xyz",
     "articles.alpha.canada.ca",
 ]
-BASE_URL = environ.get("BASE_URL", "https://list-manager.alpha.canada.ca")
+BASE_URL = environ.get("BASE_URL", "https://articles.alpha.canada.ca")
 
 description = """
 List Manager 📝 API helps you manage your lists of subscribers and easily utilize GC Notify to send messages


### PR DESCRIPTION
# Summary | Résumé

Set the BASE_URL for Unsubscribe and Confirm links to GC Articles. Since most people will be interacting with list-manager through GC Articles, this makes it a more seamless experience. We have a Proxy endpoint on GC Articles that handles these requests.

This will actually require a bit more work on the GC Articles side - the current proxy endpoint is for WP authenticated users.
