### PR TITLE
feat: generate Software Bill of Materials

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -78,3 +78,11 @@ jobs:
         run: |
           source .github/workflows/scripts/migrate.sh
           migrate
+
+      - name: Generate list-manager/${{ matrix.image }}/docker SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          docker_image: $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
+          project_name: list-manager/${{ matrix.image }}/docker
+          project_type: docker

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -1,0 +1,29 @@
+name: Generate SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - requirements.txt
+      - .github/workflows/generate_sbom.yml
+  push:
+    branches:
+      - main
+    paths:
+      - requirements.txt
+      - .github/workflows/generate_sbom.yml
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate app SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          project_name: list-manager/app
+          project_type: python        


### PR DESCRIPTION
# Summary 
Add GitHub workflows to generate SBOMs and upload them
to Dependency-Track. This will allow us to have a view of all
the dependencies used by the org and their potential
vulnerabilities.

# Related
* cds-snc/platform-sre-security-support#94