### PR TITLE
fix: Check for None value

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -666,14 +666,22 @@ def unsubscribe(
         phone = subscription.phone
         session.delete(subscription)
         session.commit()
-        if email is not None and list.unsubscribe_email_template_id is not None and len(list.unsubscribe_email_template_id) == 36:
+        if (
+            email is not None
+            and list.unsubscribe_email_template_id is not None
+            and len(list.unsubscribe_email_template_id) == 36
+        ):
             notifications_client.send_email_notification(
                 email_address=email,
                 template_id=list.unsubscribe_email_template_id,
                 personalisation={"email_address": email, "name": list.name},
             )
 
-        if phone is not None and list.unsubscribe_phone_template_id is not None and len(list.unsubscribe_phone_template_id) == 36:
+        if (
+            phone is not None
+            and list.unsubscribe_phone_template_id is not None
+            and len(list.unsubscribe_phone_template_id) == 36
+        ):
             notifications_client.send_sms_notification(
                 phone_number=phone,
                 template_id=list.unsubscribe_phone_template_id,

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -666,15 +666,14 @@ def unsubscribe(
         phone = subscription.phone
         session.delete(subscription)
         session.commit()
-
-        if email is not None and len(list.unsubscribe_email_template_id) == 36:
+        if email is not None and list.unsubscribe_email_template_id is not None and len(list.unsubscribe_email_template_id) == 36:
             notifications_client.send_email_notification(
                 email_address=email,
                 template_id=list.unsubscribe_email_template_id,
                 personalisation={"email_address": email, "name": list.name},
             )
 
-        if phone is not None and len(list.unsubscribe_phone_template_id) == 36:
+        if phone is not None and list.unsubscribe_phone_template_id is not None and len(list.unsubscribe_phone_template_id) == 36:
             notifications_client.send_sms_notification(
                 phone_number=phone,
                 template_id=list.unsubscribe_phone_template_id,


### PR DESCRIPTION
# Summary | Résumé

fixes cds-snc/gc-articles-issues#544

The empty `unsubscribe-email-template-id` was causing an error to be returned to the user.

# Test instructions | Instructions pour tester la modification

> send a message a list user that has `((unsubscribe_url))` in the template
> use that link to attempt to unsubscribe from the list
> the user should be successfully unsubscribed, and then redirected to a URL on the prod server, indicating that they have been unsubscribed