### PR TITLE
fix: upgrade to FastAPI v0.95.0

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -181,7 +181,7 @@ class ListGetPayload(ListCreatePayload):
 
 
 @app.get("/lists")
-def lists(session: Session = Depends(get_db)) -> list[ListGetPayload]:
+def lists(session: Session = Depends(get_db)):
     sub_query = (
         session.query(
             func.count(Subscription.id).label("subscriber_count"),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,7 +3,7 @@ aws-lambda-powertools==1.31.1
 boto3==1.26.99
 bcrypt==3.2.2
 email-validator==1.3.1
-fastapi==0.87.0
+fastapi==0.95.0
 logzero==1.7.0
 mangum==0.17.0
 notifications-python-client==6.4.1


### PR DESCRIPTION
# Summary
Fix the upgrade to FastAPI v0.95.0 by removing the type hinting from the `@app.get("/lists")` route. This is being done because [v0.89.0](https://fastapi.tiangolo.com/release-notes/#0890) introduced [response model type validation and filtering](https://fastapi.tiangolo.com/tutorial/response-model/), which is currently breaking the responses from the endpoint.

In order to enable this validation, the downstream services using List Manager will need to be tested first to make sure they can use the updated response format.

# Related
- cds-snc/platform-core-services#312