### PR TITLE
fix: Terraform module reference

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                  = "github.com/cds-snc/terraform-modules?ref=v0.0.49//rds"
+  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v0.0.49"
   backup_retention_period = 7
   billing_tag_value       = var.billing_code
   database_name           = "list_manager"

--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -57,7 +57,7 @@ resource "aws_sns_topic_subscription" "warning_us_east" {
 # Lambda: post notifications to Slack
 #
 module "notify_slack" {
-  source = "github.com/cds-snc/terraform-modules?ref=v0.0.49//notify_slack"
+  source = "github.com/cds-snc/terraform-modules//notify_slack?ref=v0.0.49"
 
   function_name     = "notify_slack"
   project_name      = "ListManager"

--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.49//vpc"
+  source            = "github.com/cds-snc/terraform-modules//vpc?ref=v0.0.49"
   name              = var.product_name
   billing_tag_value = var.billing_code
   high_availability = true


### PR DESCRIPTION
# Summary
Update the version reference for the Terraform modules to be after the module sub-directory.