### PR TITLE
chore: upgrade to Postgres 12.16

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,14 +1,17 @@
 module "rds" {
-  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v0.0.49"
-  backup_retention_period = 7
-  billing_tag_value       = var.billing_code
-  database_name           = "list_manager"
-  instances               = 1
+  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.1"
+  database_name           = "list_manager"  
   name                    = "list-manager"
-  preferred_backup_window = "07:00-09:00"
-  subnet_ids              = module.vpc.private_subnet_ids
+  engine_version          = "12.16"
+  instances               = 1
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
-  engine_version          = "11.17"
+  subnet_ids              = module.vpc.private_subnet_ids
+  backup_retention_period = 7
+  preferred_backup_window = "07:00-09:00"
+
+  allow_major_version_upgrade = true
+
+  billing_tag_value = var.billing_code
 }

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,6 +1,6 @@
 module "rds" {
   source                  = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.1"
-  database_name           = "list_manager"  
+  database_name           = "list_manager"
   name                    = "list-manager"
   engine_version          = "12.16"
   instances               = 1


### PR DESCRIPTION
# Summary
Upgrade the Postgres engine version to 12.16 which is the highest 12.x target allowed by the current engine version.

# Related
- https://github.com/cds-snc/platform-core-services/issues/402