### PR TITLE
fix: Postgres 12.15 upgrade target

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -2,7 +2,7 @@ module "rds" {
   source                  = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.1"
   database_name           = "list_manager"
   name                    = "list-manager"
-  engine_version          = "12.16"
+  engine_version          = "12.15"
   instances               = 1
   username                = var.rds_username
   password                = var.rds_password


### PR DESCRIPTION
# Summary
Upgrade to Postgres 12.15 as this is the highest supported Aurora Postgres version available.

# Related
- #238 
- https://github.com/cds-snc/platform-core-services/issues/402