### PR TITLE
chore: upgrade to Postgres 13.11

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       OPENAPI_URL: "/openapi.json"
  
   db:
-    image: postgres:11.16@sha256:5d2aa4a7b5f9bdadeddcf87cf7f90a176737a02a30d917de4ab2e6a329bd2d45
+    image: postgres:13.11@sha256:6d1b866074c04b8ca288120c036345ed75ae9aa7e29efcbe28a59de18a846d08
     volumes:
     - ./initdb:/docker-entrypoint-initdb.d
     restart: always
@@ -58,7 +58,7 @@ services:
       - "5433:5432"
   
   test-db:
-    image: postgres:11.16@sha256:5d2aa4a7b5f9bdadeddcf87cf7f90a176737a02a30d917de4ab2e6a329bd2d45
+    image: postgres:13.11@sha256:6d1b866074c04b8ca288120c036345ed75ae9aa7e29efcbe28a59de18a846d08
     volumes:
     - ./initdb:/docker-entrypoint-initdb.d
     restart: always

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.16@sha256:5d2aa4a7b5f9bdadeddcf87cf7f90a176737a02a30d917de4ab2e6a329bd2d45
+        image: postgres:13.11@sha256:6d1b866074c04b8ca288120c036345ed75ae9aa7e29efcbe28a59de18a846d08
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,17 +1,18 @@
 module "rds" {
-  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.1"
+  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.2"
   database_name           = "list_manager"
   name                    = "list-manager"
-  engine_version          = "12.15"
+  engine_version          = "13.11"
   instances               = 1
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
   subnet_ids              = module.vpc.private_subnet_ids
   backup_retention_period = 7
-  preferred_backup_window = "07:00-09:00"
 
-  allow_major_version_upgrade = true
+  preferred_backup_window      = "07:00-09:00"
+  preferred_maintenance_window = "wed:06:00-wed:07:00" # timezone is UTC
+  allow_major_version_upgrade  = true
 
   billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Upgrade the Postgres database engine to 13.11.
Additionally, change the maintenance window so
the upgrade is applied tonight.

# Related
- https://github.com/cds-snc/platform-core-services/issues/402