### PR TITLE
chore: upgrade RDS Postgres to 14.8

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       OPENAPI_URL: "/openapi.json"
  
   db:
-    image: postgres:13.11@sha256:6d1b866074c04b8ca288120c036345ed75ae9aa7e29efcbe28a59de18a846d08
+    image: postgres:14.8@sha256:eecfb2ab484dadaae790866c9e5090a67deeee76417f072786569bea03f53e3f
     volumes:
     - ./initdb:/docker-entrypoint-initdb.d
     restart: always
@@ -58,7 +58,7 @@ services:
       - "5433:5432"
   
   test-db:
-    image: postgres:13.11@sha256:6d1b866074c04b8ca288120c036345ed75ae9aa7e29efcbe28a59de18a846d08
+    image: postgres:14.8@sha256:eecfb2ab484dadaae790866c9e5090a67deeee76417f072786569bea03f53e3f
     volumes:
     - ./initdb:/docker-entrypoint-initdb.d
     restart: always

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:13.11@sha256:6d1b866074c04b8ca288120c036345ed75ae9aa7e29efcbe28a59de18a846d08
+        image: postgres:14.8@sha256:eecfb2ab484dadaae790866c9e5090a67deeee76417f072786569bea03f53e3f
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -2,7 +2,7 @@ module "rds" {
   source                  = "github.com/cds-snc/terraform-modules//rds?ref=v7.0.2"
   database_name           = "list_manager"
   name                    = "list-manager"
-  engine_version          = "13.11"
+  engine_version          = "14.8"
   instances               = 1
   username                = var.rds_username
   password                = var.rds_password
@@ -11,7 +11,7 @@ module "rds" {
   backup_retention_period = 7
 
   preferred_backup_window      = "07:00-09:00"
-  preferred_maintenance_window = "wed:06:00-wed:07:00" # timezone is UTC
+  preferred_maintenance_window = "thu:06:00-thu:07:00" # timezone is UTC
   allow_major_version_upgrade  = true
 
   billing_tag_value = var.billing_code


### PR DESCRIPTION
# Summary
Upgrade the Postgres engine to 14.8.  Also upgrades the maintenance window to apply the change tonight.

# Related
- https://github.com/cds-snc/platform-core-services/issues/402