### PR TITLE
chore: switch AWS credentials to OIDC roles

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 
 env:
+  AWS_REGION: ca-central-1
   GITHUB_SHA: ${{ github.sha }}
   REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/list-manager
 
@@ -50,7 +51,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/list-manager-apply
           role-session-name: ECRPush
-          aws-region: ca-central-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
         id: login-ecr

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -45,12 +45,11 @@ jobs:
           -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
           -t $REGISTRY/${{ matrix.image }}:latest .
 
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/list-manager-apply
+          role-session-name: ECRPush
           aws-region: ca-central-1
 
       - name: Login to ECR

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -10,6 +10,10 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/list-manager
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -12,12 +12,11 @@ jobs:
   docker-vulnerability-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/list-manager-plan
+          role-session-name: ECRPull
           aws-region: ca-central-1
 
       - name: Login to ECR

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 4 * * *"
 
 env:
+  AWS_REGION: ca-central-1
   ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/list-manager
 
 jobs:
@@ -17,7 +18,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/list-manager-plan
           role-session-name: ECRPull
-          aws-region: ca-central-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to ECR
         id: login-ecr

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -9,6 +9,11 @@ env:
   AWS_REGION: ca-central-1
   ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.ca-central-1.amazonaws.com/list-manager
 
+permissions:
+  id-token: write
+  contents: write
+  security-events: write
+
 jobs:
   docker-vulnerability-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -14,6 +14,10 @@ env:
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.TF_VARS_SLACK_WEBHOOK_URL }}
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   terragrunt-apply:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 env:
+  AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.31.1
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
@@ -16,14 +17,17 @@ env:
 jobs:
   terragrunt-apply:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ca-central-1
+    runs-on: ubuntu-latest     
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/list-manager-apply
+          role-session-name: TPApply
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -14,6 +14,11 @@ env:
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.TF_VARS_SLACK_WEBHOOK_URL }}
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
 jobs:
   terraform-plan:
     strategy:

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -6,8 +6,6 @@ on:
       - "terragrunt/**"
       - ".github/workflows/**"
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.31.1
@@ -29,6 +27,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT }}:role/list-manager-plan
+          role-session-name: TFPlan
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1


### PR DESCRIPTION
# Summary
Update the GitHub workflows with hard-coded AWS access credentials to use OIDC roles for authentication.

# Related
- https://github.com/cds-snc/platform-core-services/issues/459