### PR TITLE
fix: healthcheck HTTP status code on failure

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -110,14 +110,15 @@ def get_db_version(session):
     return full_name
 
 
-@app.get("/healthcheck")
-def healthcheck(session: Session = Depends(get_db)):
+@app.get("/healthcheck", status_code=200)
+def healthcheck(response: Response, session: Session = Depends(get_db)):
     try:
         full_name = get_db_version(session)
         db_status = {"able_to_connect": True, "db_version": full_name}
     except SQLAlchemyError as err:
         log.error(err)
         db_status = {"able_to_connect": False}
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
     return {"database": db_status}
 

--- a/api/tests/api_gateway/test_api_common.py
+++ b/api/tests/api_gateway/test_api_common.py
@@ -38,7 +38,7 @@ def test_healthcheck_success(mock_get_db_version, client):
 def test_healthcheck_failure(mock_log, mock_get_db_version, client):
     mock_get_db_version.side_effect = SQLAlchemyError()
     response = client.get("/healthcheck")
-    assert response.status_code == 200
+    assert response.status_code == 503
     expected_val = {"database": {"able_to_connect": False}}
     assert response.json() == expected_val
     # assert mock_log.error.assert_called_once_with(SQLAlchemyError())


### PR DESCRIPTION
# Summary
Update the `/healthcheck` endpoint so that when it cannot connect to the database, a `503 Service Unavailable` HTTP status code is returned.