### PR TITLE
fix: suppress CloudWatch errors for email validation

### DIFF
--- a/terragrunt/aws/api/cloudwatch_api.tf
+++ b/terragrunt/aws/api/cloudwatch_api.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_metric_filter" "lambda-429-errors" {
 
 resource "aws_cloudwatch_log_metric_filter" "lambda-api-errors" {
   name           = "api-errors"
-  pattern        = "?ERROR ?Error ?error"
+  pattern        = local.api_error_metric_pattern
   log_group_name = "/aws/lambda/${aws_lambda_function.api.function_name}"
 
   metric_transformation {

--- a/terragrunt/aws/api/cloudwatch_locals.tf
+++ b/terragrunt/aws/api/cloudwatch_locals.tf
@@ -1,0 +1,11 @@
+locals {
+  api_errors = [
+    "ERROR",
+    "Error",
+    "error",
+  ]
+  api_errors_skip = [
+    "email_address Not a valid email address",
+  ]
+  api_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.api_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.api_errors_skip)}*\"]"
+}


### PR DESCRIPTION
# Summary
Update the API CloudWatch error alarm so that invalid email address validation messages no longer trigger the alarm.