### PR TITLE
chore: bump docker dependency scan action

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -81,7 +81,7 @@ jobs:
           migrate
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@d6bb182e15f0cad80e7625887ae88e5830728aab # v3.0.0
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
         with:
           docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:latest"
           dockerfile_path: "${{ matrix.image }}/Dockerfile"

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -30,7 +30,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@d6bb182e15f0cad80e7625887ae88e5830728aab # v3.0.0
+        uses: cds-snc/security-tools/.github/actions/docker-scan@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
         with:
           docker_image: "${{ env.ECR_REGISTRY }}/api:latest"
           dockerfile_path: "api/Dockerfile"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,9 +7,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends ca-certificates curl git gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0 libxshmfence-dev gnupg2 postgresql-client openssh-client python3-pip vim wget xz-utils zsh entr \
     && apt-get autoremove -y && apt-get clean -y
 
-# Include global arg in this stage of the build
 ARG FUNCTION_DIR
-
 WORKDIR ${FUNCTION_DIR}
 
 RUN mkdir -p /pymodules


### PR DESCRIPTION
# Summary
Upgrade to the latest security tools docker scanning actions. As part of this change, update the API's Dockerfile to trigger a build, deploy and scan.