### PR TITLE
chore: upgrade to latest RDS module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,9 +16,9 @@
 			"version": "latest"
 		},	
 		"terraform": {
-			"version": "1.6.1",
+			"version": "1.8.2",
 			"tflint": "latest",
-			"terragrunt": "0.52.1"
+			"terragrunt": "0.58.3"
 		}
 	},
 

--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.6.1
-  TERRAGRUNT_VERSION: 0.52.1
+  TERRAFORM_VERSION: 1.8.2
+  TERRAGRUNT_VERSION: 0.58.3
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
   TF_VAR_notify_key: ${{ secrets.TF_VARS_NOTIFY_KEY }}
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -7,8 +7,8 @@ on:
       - ".github/workflows/**"
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.6.1
-  TERRAGRUNT_VERSION: 0.52.1
+  TERRAFORM_VERSION: 1.8.2
+  TERRAGRUNT_VERSION: 0.58.3
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
   TF_VAR_notify_key: ${{ secrets.TF_VARS_NOTIFY_KEY }}
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.2"
+  source                  = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.4"
   database_name           = "list_manager"
   name                    = "list-manager"
   engine_version          = "15.4"
@@ -15,4 +15,14 @@ module "rds" {
   allow_major_version_upgrade  = true
 
   billing_tag_value = var.billing_code
+}
+
+import {
+  to = module.rds.aws_security_group_rule.rds_proxy_egress
+  id = "${module.rds.proxy_security_group_id}_egress_tcp_5432_5432_self"
+}
+
+import {
+  to = module.rds.aws_security_group_rule.rds_proxy_ingress
+  id = "${module.rds.proxy_security_group_id}_ingress_tcp_5432_5432_self"
 }


### PR DESCRIPTION
# Summary
Upgrade to the latest RDS module, which changes to standalone security group rules.

This PR makes sure they are imported properly as Terraform does not handle inline SG rule changes well.

Also includes an update to Terraform and Terragrunt versions.

# Related
- https://github.com/cds-snc/terraform-modules/pull/481