### PR TITLE
chore: disable Route53 health check

### DIFF
--- a/terragrunt/aws/api/cloudwatch_api.tf
+++ b/terragrunt/aws/api/cloudwatch_api.tf
@@ -162,23 +162,3 @@ resource "aws_cloudwatch_metric_alarm" "api-invalid-auth-token-warning" {
     service = "api"
   }
 }
-
-resource "aws_cloudwatch_metric_alarm" "route53_list_manager_health_check" {
-  provider = aws.us-east-1
-
-  alarm_name          = "route53-list-manager-health-check"
-  alarm_description   = "Health check failing for the list manager"
-  comparison_operator = "LessThanThreshold"
-  metric_name         = "HealthCheckStatus"
-  namespace           = "AWS/Route53"
-  period              = "60"
-  evaluation_periods  = "2"
-  statistic           = "Average"
-  threshold           = "1"
-  treat_missing_data  = "breaching"
-  alarm_actions       = [aws_sns_topic.warning_us_east.arn]
-  ok_actions          = [aws_sns_topic.warning_us_east.arn]
-  dimensions = {
-    HealthCheckId = aws_route53_health_check.list_manager.id
-  }
-}

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -11,16 +11,3 @@ resource "aws_route53_record" "list_manager_A" {
     evaluate_target_health = false
   }
 }
-
-resource "aws_route53_health_check" "list_manager" {
-  fqdn              = var.domain_name
-  port              = 443
-  type              = "HTTPS"
-  resource_path     = "/healthcheck"
-  failure_threshold = "3"
-  request_interval  = "30"
-
-  tags = {
-    CostCenter = var.billing_code
-  }
-}


### PR DESCRIPTION
# Summary
Disable the Route53 health check, which we've been using as a low budget function warmer.